### PR TITLE
Web updated design and shortcut

### DIFF
--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -46,6 +46,9 @@ const commands: TextCommand[] = dbCommands.map((command) => {
         <div class="mt-12">
           <div id="js-results"></div>
         </div>
+
+        <!-- Breathing room near the bottom -->
+        <div class="h-[80vh]"></div>
       </div>
     </main>
   </command-table>

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -100,6 +100,7 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 
       // Register the event listeners
       this.input.addEventListener("input", this.onInputChanged)
+      document.addEventListener("keydown", this.onDocumentKeyDown)
 
       // Launch
       this.makeDefaultResults()
@@ -211,6 +212,17 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 
     onInputChanged = () => {
       this.setCommandQuery(this.input.value)
+    }
+
+    onDocumentKeyDown = (event: KeyboardEvent): void => {
+      const isSlash = event.code === "Slash"
+      const isInputAlreadyInFocus = document.activeElement === this.input
+      if (!isSlash || isInputAlreadyInFocus) {
+        return
+      }
+
+      this.input.focus()
+      event.preventDefault()
     }
   }
 

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -16,14 +16,38 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 
 <HtmlLayout pageTitle={"Adam Learns command search"}>
   <command-table data-commands={JSON.stringify(commands)}>
-    <div class="search-area">
-      <label>
-        Search commands and responses:
-        {/* eslint-disable-next-line astro/jsx-a11y/no-autofocus */}
-        <input type="search" name="command" required autofocus />
-      </label>
-    </div>
-    <table></table>
+    <main class="flex min-h-screen w-full justify-center bg-blue-50/10 px-4">
+      <div class="w-full max-w-2xl">
+        <div>
+          <h1 class="mt-16 text-center text-3xl font-bold text-gray-800">
+            Abbott Commands
+          </h1>
+
+          <div>
+            <label
+                for="js-query-input"
+                class="mt-4 block text-center text-gray-500"
+            >
+              Search commands and responses
+            </label>
+
+            <input
+                type="search"
+                name="command"
+                id="js-query-input"
+                class="mt-4 h-16 w-full px-4 py-2 rounded font-mono text-lg shadow outline-cyan-700"
+                placeholder="Search commands or responses"
+                required
+                autofocus
+            />
+          </div>
+        </div>
+
+        <div class="mt-12">
+          <div id="js-results"></div>
+        </div>
+      </div>
+    </main>
   </command-table>
 </HtmlLayout>
 <script>
@@ -35,37 +59,47 @@ const commands: TextCommand[] = dbCommands.map((command) => {
   class CommandTable extends HTMLElement {
     input: HTMLInputElement
     commands: TextCommand[]
-    table: HTMLTableElement
+    results: HTMLDivElement
     fuse: Fuse<TextCommand>
+
     constructor() {
       super()
 
-      if (this.dataset.commands === undefined) {
-        throw new Error("Missing commands attribute.")
-      }
-      const input = this.querySelector("input")
+      // Query and initialize the elements
+      const input = this.querySelector<HTMLInputElement>("#js-query-input")
       if (input === null) {
         throw new Error("Missing input element.")
       }
 
-      const table = this.querySelector("table")
-      if (table === null) {
-        throw new Error("Missing table element.")
+      const results = this.querySelector<HTMLDivElement>("#js-results")
+      if (results === null) {
+        throw new Error("Missing results element.")
       }
+
+      this.input = input
+      this.results = results
+
+      // Initialize the commands
+      if (this.dataset.commands === undefined) {
+        throw new Error("Missing commands attribute.")
+      }
+
       this.commands = JSON.parse(this.dataset.commands)
       this.commands.forEach((command) => {
         command.updated_at = new Date(command.updated_at)
       })
-      this.input = input
-      this.table = table
 
+      // Light the fuse (for fuzzy search)
       this.fuse = new Fuse(this.commands, {
         keys: ["name", "response"],
         includeScore: true,
       })
-      this.input.addEventListener("input", this.onInputChanged)
-      this.setDefaultTableContents()
 
+      // Register the event listeners
+      this.input.addEventListener("input", this.onInputChanged)
+
+      // Launch
+      this.makeDefaultResults()
       this.readInitialQueryParams()
     }
 
@@ -78,51 +112,60 @@ const commands: TextCommand[] = dbCommands.map((command) => {
       }
     }
 
-    setTableContents(tbody: string) {
-      this.table.innerHTML = `<thead>
-<tr>
-  <th scope="col">Command</th>
-  <th scope="col">Response</th>
-  <th scope="col">Last updated</th>
-</tr>
-</thead>
-<tbody>
-  ${tbody}
-</tbody>`
+    renderCommandHtml(command: TextCommand): string {
+      const linkClassName = [
+        "transition-all duration-75",
+        "underline decoration-2",
+        "text-gray-600 decoration-blue-600",
+        "hover:text-gray-500 hover:decoration-teal-500",
+        "active:text-gray-600 active:decoration-blue-600",
+      ].join(" ")
+
+      return `
+<div class="w-full">
+  <h2 class="mb-1 font-mono font-bold text-xl text-gray-800">
+    ${command.name}
+  </h2>
+
+  <p class="mb-4 text-xs text-gray-400">
+    ${command.updated_at.toLocaleDateString()}
+  </p>
+  
+  <div class="mb-2 text-gray-600 max-w-[35em]">
+    ${linkifyHtml(safeHtml`${command.response}`, { className: linkClassName })}
+  </div>
+
+  <hr />
+</div>
+`
     }
 
-    makeTableRow = (
-      commandName: string,
-      commandResponse: string,
-      updatedAt: Date,
-    ) => {
-      return `<tr>
-<th scope="row">${commandName}</th>
-<td>${linkifyHtml(safeHtml`${commandResponse}`)}</td>
-<td>${updatedAt.toLocaleDateString()}</td>
-</tr>`
+    renderResultsHtml(commands: TextCommand[]): string {
+      const commandsHtml = commands.map(this.renderCommandHtml).join("")
+
+      return `
+<div class="flex flex-col gap-4">
+  ${commandsHtml}
+</div>
+`
     }
 
-    makeTable(textCommands: TextCommand[]) {
-      const tbody = textCommands
-        .map(({ name, response, updated_at }) => {
-          return this.makeTableRow(name, response, updated_at)
-        })
-        .join("")
-      this.setTableContents(tbody)
+    makeResults(commands: TextCommand[]): void {
+      this.results.innerHTML = this.renderResultsHtml(commands)
     }
 
-    setDefaultTableContents = () => {
+    makeDefaultResults = () => {
       const sortedByName = this.commands.sort((a, b) => {
         return a.name.localeCompare(b.name)
       })
-      this.makeTable(sortedByName)
+
+      this.makeResults(sortedByName)
     }
 
-    setCommandQuery = (query: string) => {
+    setCommandQuery = (query: string): void => {
       if (query.trim() === "") {
         history.replaceState({}, "", location.pathname)
-        this.setDefaultTableContents()
+        this.makeDefaultResults()
         return
       }
       history.replaceState({}, "", "?query=" + query)
@@ -132,7 +175,7 @@ const commands: TextCommand[] = dbCommands.map((command) => {
       })
       const results = fuse.search(query)
 
-      this.makeTable(results.map((r) => r.item))
+      this.makeResults(results.map((r) => r.item))
     }
 
     onInputChanged = () => {
@@ -142,84 +185,3 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 
   customElements.define("command-table", CommandTable)
 </script>
-<style>
-  :global(body) {
-    background-color: #006bc9;
-  }
-  :global(a) {
-    color: deepskyblue;
-  }
-  :global(a:hover) {
-    color: aliceblue;
-  }
-  :global(table) {
-    color: white;
-    min-width: 100%;
-  }
-  :global(td) {
-    padding: 0.2em;
-  }
-  :global(tr) {
-    padding: 30px;
-  }
-  :global(tr):nth-child(even) {
-    background-color: #13334e;
-  }
-  :global(tr):nth-child(odd) {
-    background-color: #122d45;
-  }
-  .search-area {
-    padding: 10px;
-    color: white;
-    font-size: 1.4rem;
-  }
-  .search-area input {
-    background-color: #e0f1ff;
-    color: black;
-    padding: 5px;
-  }
-
-  :global(tr) > :global(*) {
-    width: 15%;
-    word-break: break-word;
-  }
-  :global(tr) :global(td):nth-child(2) {
-    width: 70%;
-  }
-  :global(tr) :global(td):last-child {
-    text-align: center;
-  }
-  @media screen and (max-width: 750px) {
-    :global(table),
-    :global(tbody),
-    :global(td),
-    :global(th),
-    :global(thead),
-    :global(tr) {
-      display: block;
-    }
-    :global(thead) :global(tr) {
-      display: none;
-    }
-    :global(tbody) :global(tr) :global(th[scope="row"]):before {
-      content: "Command";
-    }
-    :global(tbody) :global(tr) :global(td):nth-of-type(1):before {
-      content: "Response";
-      font-weight: bold;
-    }
-    :global(tbody) :global(tr) :global(td):nth-of-type(2):before {
-      content: "Last Updated";
-      font-weight: bold;
-    }
-    :global(table) :global(tbody) :global(td):before,
-    :global(table) :global(tbody) :global(th):before {
-      display: block;
-      width: 100%;
-    }
-    :global(tr) > :global(*) {
-      width: 100% !important;
-      text-align: center;
-    }
-  }
-</style>

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -140,7 +140,27 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 `
     }
 
+    renderZeroResults(): string {
+      return `
+<div class="flex flex-col gap-4">
+  <div>
+    <p class="mb-2 text-gray-400 text-xl">
+      No command matches that query.
+    </p>
+  
+    <p class="text-gray-400">
+      Please feel free to ask about this on the next stream or at any time via Discord.
+    </p>
+  </p>
+</div>
+`
+    }
+
     renderResultsHtml(commands: TextCommand[]): string {
+      if (commands.length === 0) {
+        return this.renderZeroResults();
+      }
+
       const commandsHtml = commands.map(this.renderCommandHtml).join("")
 
       return `

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -127,7 +127,7 @@ const commands: TextCommand[] = dbCommands.map((command) => {
 
       return `
 <div class="w-full">
-  <h2 class="mb-1 font-mono font-bold text-xl text-gray-800">
+  <h2 class="mb-1 font-mono font-bold text-xl text-gray-800" tabindex="0">
     ${command.name}
   </h2>
 

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -167,8 +167,16 @@ const commands: TextCommand[] = dbCommands.map((command) => {
       const commandsHtml = commands.map(this.renderCommandHtml).join("")
 
       return `
-<div class="flex flex-col gap-4">
-  ${commandsHtml}
+<div>
+  <div class="mb-4">
+    <p class="text-gray-500">
+      Found: <span class="ml-2 text-lg text-gray-600 font-bold">${commands.length}</span>
+    </p>
+  </div>
+
+  <div class="flex flex-col gap-4">
+    ${commandsHtml}
+  </div>
 </div>
 `
     }


### PR DESCRIPTION
**Describe the pull request**

Updated the Web Interface design (UI) for Abbott's commands and added some convenient functionality (UX)

**Why**

To make the web interface look more roomy (kind of objective) and overall look better (strictly ~~objective~~ subjective)

Also added some convenient keyboard shortcuts

**How**

Please read the commit messages for additional details:

- Update Web Interface UI to be more roomy and uniform
- Add special UI for the case where the results are 0
- Add some breathing room near the bottom of the page
- Add number of found commands to the results
- Add global slash (/) keyboard shortcut to focus on the input
- Add ability to tab through command names

**Screenshots**
Default view:  
![image](https://github.com/AdamLearns/Abbott/assets/11218993/87843093-4d95-4537-978f-b6bbb629e2c7)

Limited results:  
![image](https://github.com/AdamLearns/Abbott/assets/11218993/fad6f22a-9a22-4303-8524-571c28ac8901)

No results:  
![image](https://github.com/AdamLearns/Abbott/assets/11218993/3bf8bed4-7aa4-4591-9a1e-1bf8fea6d190)

